### PR TITLE
Deal with non-standard slits gracefully

### DIFF
--- a/tilsotua/LRIS_Mask_Coords_to_WCS.py
+++ b/tilsotua/LRIS_Mask_Coords_to_WCS.py
@@ -171,25 +171,31 @@ def xytowcs(data_input_name:str,output_file:str,obj_file:str=None, file1:str=Non
     the missing data filled in.
 
     Args:
-        data_input_name (str): Path to the input FITS file
-            from the mask design ingestion process. i.e. the
-            FITS file generated when AUTOSLIT .file3 ascii
-            files are fed mask submission webpage. THis can be the .file3 autoslit
-            output, in which case a FITS file for the mask will be automatically
-            generated before the rest of the calcuations are done.
+
+        data_input_name (str): Path to the input FITS file or autoslit-produced
+            ".file3" file. The FITS file would be produced during the mask design
+            ingestion process. i.e. the FITS file generated when AUTOSLIT .file3
+            ascii files are fed mask submission webpage.  If the input is a .file3,
+            a FITS file for the mask will be automatically generated.
+
         output_file (str): Name of the output file you'd
             like to generate. DO NOT INCLUDE FILE EXTENSIONS
             like .fits or .csv. e.g. "output_file".
+
         obj_file (str, optional): Path to the object catalog
             file that was used as an input to AUTOSLIT when generating
             the mask design files corresponding to data_input_name.
+
         file1 (str, optional): Path to the list of objects generated
             by AUTOSLIT. Has the extension of ".file1" by default.
+
         autofile (str, optional): Path to the autoslit output file
             (extension ".file3") to be used if the mask FITS file needs to
             be generated before anything else is done.
+
         mag_band (str, optional): Filter band in which AUTOSLIT
             was fed object magnitudes.
+
     Returns:
         None
     """
@@ -208,6 +214,7 @@ def xytowcs(data_input_name:str,output_file:str,obj_file:str=None, file1:str=Non
     mask_angle = 8.06 * rpd #angle of mask to the focal plane
     bend = 1.94 * rpd #angle of the bend in the mask
     x_center = 305. #point treated as the center on the ccd
+
     #  catalog_keyword = 'panstarrs'   #uncomment the desired catalog to be used
     catalog_keyword = 'gaia'
     #   catalog_keyword = 'custom'
@@ -219,7 +226,9 @@ def xytowcs(data_input_name:str,output_file:str,obj_file:str=None, file1:str=Non
     #================================================================================================================================
 
     #read in the data\
-    #copy the original file to a new file that will be the one to which the results are added
+    #copy the original file to a new file that will be the one to
+    # which the results are added
+        
     copyfile(data_input_name+'.fits', output_file+'.fits')
     #Open the copied file
     hdu=fits.open(output_file+'.fits',mode='update')

--- a/tilsotua/use_autoslit_input.py
+++ b/tilsotua/use_autoslit_input.py
@@ -48,17 +48,29 @@ def gen_from_auto(autofile):
                 matches.append(i)
         return(matches)
 
-    slit_start = lines_that_equal('newrow\n',content)
-    slit_pos = Table(names=['slitX1','slitY1','slitX2','slitY2','slitX3','slitY3','slitX4','slitY4'], dtype=(float,float,float,float,float,float,float,float))
+    slit_start_text = 'newrow\n'
+    slit_start = lines_that_equal(slit_start_text,content)
+    slit_pos = Table(names=['slitX1','slitY1','slitX2','slitY2',
+                            'slitX3','slitY3','slitX4','slitY4'],
+                            dtype=(float,float,float,float,float,float,float,float))
+
     for i in range(len(slit_start)-1):
         ind = slit_start[i]
 
-        X,Y = content[ind+1].split()[0],content[ind+1].split()[1]
-        X2,Y2 = content[ind+2].split()[0],content[ind+2].split()[1]
-        X3,Y3 = content[ind+3].split()[0],content[ind+3].split()[1]
-        X4,Y4 = content[ind+4].split()[0],content[ind+4].split()[1]
+        Z = []
+        j = ind+1
+        while content[j] != slit_start_text:
+            # This variable holds both X and Y positions:
+            Z.extend(content[j].split()[0:2])
+            j+=1
 
-        slit_pos.add_row([X,Y,X2,Y2,X3,Y3,X4,Y4])
+        # The last vertex is a repeat of the first. Remove it.
+        Z = Z[:len(Z)-2]
+
+        # Test that we have only 4 vertices. These are the standard slits.
+        if len(Z) == 8:
+            slit_pos.add_row(Z)
+
 
     #write the new fits file with the same structure as the UCO/Lick archive
     copyfile(dir_loc+'/blank_template.fits', autofile+'.fits')


### PR DESCRIPTION
New approach to reading slits in in autoslit ".file3" tables. Now only adds slits with 4 vertices to output list.  